### PR TITLE
remove extra margins and post-right-alignment from blockquote styling

### DIFF
--- a/website/themes/even/sass/_main.scss
+++ b/website/themes/even/sass/_main.scss
@@ -54,7 +54,7 @@ main {
     }
 
     blockquote {
-      margin: 2em 0;
+      margin: 0 0;
       padding: 10px 20px;
       position: relative;
       color: rgba(#34495e, 0.8);
@@ -69,18 +69,8 @@ main {
       blockquote {
           margin: 0em 0 2em 0;
       }
-
-
-      blockquote + p {
-          margin: -1.5em 0 0 0;
-          text-align: right;
-      }
     }
 
-    blockquote + p {
-        margin: -1.5em 0 1.5em 0;
-        text-align: right;
-    }
 
     table {
       width: 100%;


### PR DESCRIPTION
The current styling code includes a large (2em) margin on top of blockquote, and furthermore, makes the following paragraph right aligned. For an example, the [latest post](https://www.cs.cmu.edu/~csd-phd-blog/2025/llm-checklist-assistant/) has:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/20a643e9-10b3-4d18-8ab9-6ecd7ceb3ace" />

This PR proposes to simply remove such styling decisions, trying to minimize the design choices made by the template.
